### PR TITLE
fix: exclude release please branches from regular ci runs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,6 +5,8 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+    paths-ignore:
+      - 'CHANGELOG.md'
 
 
 jobs:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -5,6 +5,10 @@ on:
 
 name: release-please
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   release-please:
     runs-on: ubuntu-latest
@@ -12,5 +16,5 @@ jobs:
       - uses: googleapis/release-please-action@v4
         id: release
         with:
-          token: ${{ secrets.TEST_CONTENTS_PULL_REQUEST_WRITE_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           release-type: simple


### PR DESCRIPTION
Try excluding release-please branches by excluding CI tests when only `CHANGELOG.md` is changed.